### PR TITLE
Fixed warning for `Builder::fromCli()`.

### DIFF
--- a/src/Util/Builder.php
+++ b/src/Util/Builder.php
@@ -13,7 +13,7 @@ use HackPack\HackUnit\Test\Runner;
 use HackPack\HackUnit\Test\SuiteBuilder;
 
 final class Builder {
-  public function fromCli(Traversable<string> $args): this {
+  public static function fromCli(Traversable<string> $args): this {
     return new self(Options::fromCli($args));
   }
 


### PR DESCRIPTION
Changed method to be static.

Warning given:
Strict Warning: Non-static method
HackPack\HackUnit\Util\Builder::fromCli() should not be called
statically in vendor/hackpack/hackunit/bin/hackunit on line 29.